### PR TITLE
Add async methods to module `trace`

### DIFF
--- a/src/trace.rs
+++ b/src/trace.rs
@@ -136,7 +136,7 @@ pub async fn async_scope<T>(name: &'static str, f: impl Future<Output = T>) -> T
     // Safety: accessing global mut, not threadsafe.
     unsafe {
         match &mut TRACE {
-            None =>  f.await,
+            None => f.await,
             Some(t) => t.async_scope(name, f).await,
         }
     }


### PR DESCRIPTION
This patch adds two `async` methods to module `trace` which can be used by project [moon](https://github.com/moonbitlang/moon). See https://github.com/moonbitlang/moon/pull/276 for more information.