### PR TITLE
Update add_build to return BuildId.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -293,7 +293,7 @@ impl Graph {
     }
 
     /// Add a new Build, generating a BuildId for it.
-    pub fn add_build(&mut self, mut build: Build) -> anyhow::Result<()> {
+    pub fn add_build(&mut self, mut build: Build) -> anyhow::Result<BuildId> {
         let new_id = self.builds.next_id();
         for &id in &build.ins.ids {
             self.files.by_id[id].dependents.push(new_id);
@@ -324,7 +324,7 @@ impl Graph {
             build.outs.remove_duplicates();
         }
         self.builds.push(build);
-        Ok(())
+        Ok(new_id)
     }
 }
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -166,7 +166,8 @@ impl Loader {
         build.rspfile = rspfile;
         build.pool = pool;
 
-        self.graph.add_build(build)
+        self.graph.add_build(build)?;
+        Ok(())
     }
 
     fn read_file(&mut self, id: FileId) -> anyhow::Result<()> {


### PR DESCRIPTION
This is for the MoonBit task builder to read and map the build IDs to custom metadata. 

The rest of the project already has `BuildId` exposed (e.g. in build progress), but just not in `add_build` where it's generated. This PR adds that so we can get the correspondance between builds and build plan nodes, and print custom build metadata during output.