### PR TITLE
not print "failed" when executing a command failed

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -305,15 +305,15 @@ impl FancyState {
                 build_message(build, true)
             )),
             Termination::Failure => {
-                // Show failed message, with command line if in verbose mode.
+                // Show the failure message with command line if in verbose mode.
+                // If not verbose, there will be diagnostic output so no need
+                // to show the message here.
                 if self.verbose {
                     self.log_when_failed(&format!(
                         "{} {}",
                         "failed:".red().bold(),
                         build_message(build, true)
                     ))
-                } else {
-                    self.log_when_failed(&format!("{}", "failed".red().bold()))
                 }
             }
         };


### PR DESCRIPTION
This is to work together with diagnostics deduplication. The diagnostics will be collected and processed before emitted. So if there are still message like "fail: xxxxx" users will see several consecutive "fail: xxxxx"  and then the actual diagnostics.