### PR TITLE
Hide dumb failed command unless verbose

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -111,7 +111,12 @@ impl Progress for DumbConsoleProgress {
                 self.log_when_failed(&format!("interrupted: {}", build_message(build, true)))
             }
             Termination::Failure => {
-                self.log_when_failed(&format!("failed: {}", build_message(build, true)))
+                // Show the failure message with command line if in verbose mode.
+                // If not verbose, there will be diagnostic output so no need
+                // to show the message here.
+                if self.verbose {
+                    self.log_when_failed(&format!("failed: {}", build_message(build, true)))
+                }
             }
         };
         if !result.output.is_empty() {

--- a/tests/e2e/regen.rs
+++ b/tests/e2e/regen.rs
@@ -99,7 +99,8 @@ rule regen
 
     // Run: regenerate and fail.
     let out = space.run(&mut n2_command(vec!["out"]))?;
-    assert_output_contains(&out, "failed:");
+    assert_output_contains(&out, "sh ./gen.sh");
+    assert_output_not_contains(&out, "failed:");
 
     Ok(())
 }


### PR DESCRIPTION
This applies the existing fancy-progress behavior to dumb progress as well: failed command lines are only printed when verbose mode is enabled.

Moon captures compiler diagnostics through the progress callback, so the unconditional dumb-mode `failed: <cmd>` line leaks a full `moonc` invocation into default CLI output even though diagnostics are already rendered.

Tested:
- `cargo test`