### PR TITLE
fix: disable fancy progress with TERM=dumb

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,6 +1,9 @@
 #[cfg(unix)]
 mod unix {
     pub fn use_fancy() -> bool {
+        if matches!(std::env::var("TERM").as_deref(), Ok("dumb")) {
+            return false;
+        }
         unsafe {
             libc::isatty(/* stdout */ 1) == 1
         }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 mod unix {
     pub fn use_fancy() -> bool {
-        if matches!(std::env::var("TERM").as_deref(), Ok("dumb")) {
+        if std::env::var("TERM").as_deref() == Ok("dumb") {
             return false;
         }
         unsafe {


### PR DESCRIPTION
This PR disables fancy progress when `TERM` is set to `dumb`, falling back to the plain `DumbConsoleProgress` output. This behavior can be found in `cargo` and other tools that could run in non-TTY environments:
- [rust-lang/cargo/src/cargo/util/progress.rs#L62](https://github.com/rust-lang/cargo/blob/71b70c095bb15e278ab9f0f808397c8033079888/src/cargo/util/progress.rs#L62)
- [rust-lang/cargo/src/doc/src/reference/environment-variables.md#L77](https://github.com/rust-lang/cargo/blob/71b70c095bb15e278ab9f0f808397c8033079888/src/doc/src/reference/environment-variables.md?plain=1#L77)

I encountered a rendering issue mainly in Neovim when a git hook that runs `moon check` is triggered before committing, for example. Since stdout is still a TTY, the fancy progress renderer emits the raw escape sequences instead of an animated bar.

**Output**
```text
^[[J[--------------------                    ] 0/4 done, 0/2 running
^[[J[====================----------          ] 2/4 done, 0/1 running
check oe/mooning/cmd/main
^[[J[==============================----------] 3/4 done, 1/1 running
check oe/mooning/cmd/main (blackbox test)
^[[JFinished. moon: ran 2 tasks, now up to date
```

**Expected**
```text
Finished. moon: ran 2 tasks, now up to date
```

As a workaround I've been piping through `cat`: `moon check 2>&1 | cat` to force a non-TTY.